### PR TITLE
More configurable post index pages

### DIFF
--- a/src/nunjucks/createNunjucksEnv.ts
+++ b/src/nunjucks/createNunjucksEnv.ts
@@ -9,14 +9,14 @@ import { MarkdownExtension } from './MarkdownExtension';
 
 // Wrap a filter function to print out proper stack trace in case of error
 function wrapFilter(filter: (...args: any[]) => any): (...args: any[]) => any {
+  // eslint-disable-next-line consistent-return
   return function wrappedFilter(this: unknown, ...args: unknown[]): unknown {
     try {
       return filter.call(this, ...args);
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.log(err.stack);
+      console.log(`Fatal error in filter ${filter.name}: \n ${err.stack}`);
       process.exit(1);
-      throw err;
     }
   };
 }

--- a/src/nunjucks/filters/assetUrl.ts
+++ b/src/nunjucks/filters/assetUrl.ts
@@ -11,7 +11,7 @@ import { expectString } from '../../utils/expectString';
  * @param input
  */
 export function assetUrl(this: NunjucksContext, input: string): string {
-  let filename = input;
+  let filename = expectString(input);
 
   // Return absolute URLs unchanged
   if (filename.match(/^[a-z]+:\/\/.+/)) {

--- a/src/nunjucks/filters/assetUrl.ts
+++ b/src/nunjucks/filters/assetUrl.ts
@@ -10,8 +10,8 @@ import { expectString } from '../../utils/expectString';
  * @param this
  * @param input
  */
-export function assetUrl(this: NunjucksContext, input: string): string {
-  let filename = expectString(input);
+export function assetUrl(this: NunjucksContext, input: unknown): string {
+  const filename = expectString(input);
 
   // Return absolute URLs unchanged
   if (filename.match(/^[a-z]+:\/\/.+/)) {
@@ -20,11 +20,8 @@ export function assetUrl(this: NunjucksContext, input: string): string {
 
   const assetManifest = this.ctx.assetManifest
     ? expectStringDictionary(this.ctx.assetManifest) : {};
-  if (input in assetManifest) {
-    filename = assetManifest[input];
-  }
-
+  const output = assetManifest[filename] || filename;
   const baseUrl = ensureNotEndsWith(expectString(this.ctx.baseUrl), '/');
 
-  return `${baseUrl}/${filename}`;
+  return `${baseUrl}/${output}`;
 }


### PR DESCRIPTION
* Add configurable output filename, template and vars for first and last post index pages, with defaults that apply to all pages.
* Runtime typecheck the input to the `assetUrl` filter.
* Print a slightly more informative error message when a filter throws an error.